### PR TITLE
Moving var declaration out of argument list to make it build in swift 2.2

### DIFF
--- a/SwiftSockets/FileDescriptor.swift
+++ b/SwiftSockets/FileDescriptor.swift
@@ -65,10 +65,12 @@ public struct FileDescriptor: IntegerLiteralConvertible, NilLiteralConvertible {
     return ( nil, buf )
   }
   
-  public func write<T>(buffer: [ T ], var count: Int = -1)
+  public func write<T>(buffer: [ T ], count: Int = -1)
                 -> ( ErrorType?, Int )
   {
     guard buffer.count > 0 else { return ( nil, 0 ) }
+    
+    var count = count
     
     if count < 0 { count = buffer.count }
     


### PR DESCRIPTION
Swift 2.2 removes var declarations in argument lists. This change makes it compile under swift 2.2 toolchain again.