### PR TITLE
Slight changes to help support Xcode 8 and Swift 2.3 Legacy version.

### DIFF
--- a/Sources/SwiftSockets/ActiveSocket.swift
+++ b/Sources/SwiftSockets/ActiveSocket.swift
@@ -325,9 +325,7 @@ public extension ActiveSocket { // writing
 #if os(Linux)
     let asyncData = dispatch_data_create(b, bufsize, queue!, nil)
 #else /* os(Darwin) */ // TBD
-    guard let asyncData = dispatch_data_create(b, bufsize, queue!, nil) else {
-      return false
-    }
+    let asyncData = dispatch_data_create(b, bufsize, queue!, nil)
 #endif /* os(Darwin) */
     
     write(data: asyncData)
@@ -354,9 +352,7 @@ public extension ActiveSocket { // writing
 #if os(Linux)
     let asyncData = dispatch_data_create(b, bufsize, queue!, nil);
 #else /* os(Darwin) */
-    guard let asyncData = dispatch_data_create(b, bufsize, queue!, nil) else {
-      return false
-    }
+    let asyncData = dispatch_data_create(b, bufsize, queue!, nil)
 #endif /* os(Darwin) */
 
     write(data: asyncData)

--- a/Sources/SwiftSockets/PassiveSocket.swift
+++ b/Sources/SwiftSockets/PassiveSocket.swift
@@ -117,15 +117,12 @@ public class PassiveSocket<T: SocketAddress>: Socket<T> {
     )
 #endif
 #else // os(Darwin)
-    guard let listenSource = dispatch_source_create(
+    let listenSource = dispatch_source_create(
       DISPATCH_SOURCE_TYPE_READ,
       UInt(fd.fd), // is this going to bite us?
       0,
       q
     )
-    else {
-      return false
-    }
 #endif // os(Darwin)
     
     let lfd = fd.fd

--- a/SwiftSockets.xcodeproj/project.pbxproj
+++ b/SwiftSockets.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 				ENABLE_TESTABILITY = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -579,6 +580,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
These are the changes to help support XCode 8 and Swift 2.3 (Legacy Edition).

I'm not sure if this is something that should go into Master, but for the most part, everyone is migrating to XCode 8 and that only allows running the Swift 2.3 (Legacy support) version or Swift 3.0.   So it probably should go into master, but that's up to you.  There's a project setting change here and 3 code changes to work properly.   I've tested the changes outside of this project in our own internal project first before creating this pull request.

If possible, just putting it into a Swift2_3 branch would work as I use cocoapods and can pull by branch or tag.