### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ a chat.
 Any suggestions on how to improve the code are welcome. I expect lots and lots
 :-)
 
-###Targets
+### Targets
 
 The project includes three targets:
 - SwiftSockets
@@ -41,7 +41,7 @@ On Linux the included ARIEchoServer/ARIFetch apps do not build, but this one
 does and is embedded:
 [SwiftyEchoDaemon](http://www.alwaysrightinstitute.com/SwiftyEchoDaemon/).
 
-####SwiftSockets
+#### SwiftSockets
 
 A framework containing the socket classes and relevant extensions. It takes a
 bit of inspiration from the [SOPE](http://sope.opengroupware.org) NGStreams
@@ -73,7 +73,7 @@ let socket = ActiveSocket<sockaddr_in>()!
   }
 ```
 
-####Using SwiftSockets with Swift Package Manager
+#### Using SwiftSockets with Swift Package Manager
 
 To use SwiftSockets in your SPM project, just add it as a dependency in your
 `Package.swift` file, like so:
@@ -91,7 +91,7 @@ To use SwiftSockets in your SPM project, just add it as a dependency in your
     )
 
 
-####ARIEchoServer / SwiftyEchoDaemon
+#### ARIEchoServer / SwiftyEchoDaemon
 
 There is the ARIEchoServer for Xcode and SwiftEchoDaemon for Package Manager
 installs. Your choize, both are equally awezome.
@@ -112,7 +112,7 @@ connect to it in the Terminal.app via ```telnet 1337```.
 
 ![](http://i.imgur.com/mzXANTC.png)
 
-####ARIFetch
+#### ARIFetch
 
 Connects a socket to some end point, sends an HTTP/1.0 GET request with some
 awesome headers, then shows the results the server sends. Cocoa app.
@@ -122,7 +122,7 @@ Why HTTP/1.0? Avoids redirects on www.apple.com :-)
 ![](http://i.imgur.com/nRhADxg.png)
 
 
-###Goals
+### Goals
 
 - [x] Max line length: 80 characters
 - [ ] Great error handling
@@ -209,7 +209,7 @@ Why HTTP/1.0? Avoids redirects on www.apple.com :-)
 - [x] Linux support
 - [x] Swift 3 2016-03-16
 
-###Why?!
+### Why?!
 
 This is an experiment to get acquainted with Swift. To check whether something
 real can be implemented in 'pure' Swift. Meaning, without using any Objective-C
@@ -217,7 +217,7 @@ Cocoa classes (no NS'ism).
 Or in other words: Can you use Swift without writing all the 'real' code in
 wrapped Objective-C? :-)
 
-###Contact
+### Contact
 
 [@helje5](http://twitter.com/helje5) | helge@alwaysrightinstitute.com
 

--- a/SwiftIssues.md
+++ b/SwiftIssues.md
@@ -6,7 +6,7 @@ Presumably they fix most of them pretty quickly.
 
 FIXME: Collect and list all issues :-)
 
-###Bugs
+### Bugs
 
 - No access to ioctl() (presumably due to varargs)
 - No access to fcntl() (presumably due to varargs)
@@ -18,15 +18,15 @@ FIXME: Collect and list all issues :-)
   no var)
 - Would be nice if Swift would allow chaining of Void methods (.onRead {} .onWrite {}) - right now all the methods have to return self manually.
 
-###How To?
+### How To?
 
-####Error Handling
+#### Error Handling
 
 I'm not sure how we are supposed to handle errors in Swift. Maybe using some
 enum for the error codes and a fallback value (e.g. the file descriptor) for
 the success case. Kinda like an Optional, with more fail values than nil.
 
-####Casting C Structures
+#### Casting C Structures
 
 How should we cast between typed pointers? Eg bind() takes a &sockaddr, but the
 actual structure is variable (eg a sockaddr_in).
@@ -41,7 +41,7 @@ let bptr = CConstPointer<sockaddr>(nil, bvptr.value)
 ```
 Which doesn't feel right.
 
-####Flexible Length C Structures
+#### Flexible Length C Structures
 
 I guess this can be done with UnsafePointer. Structures like sockaddr_un,
 which embed the path within the structure and thereby have a different size.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
